### PR TITLE
Added 2 tests for checking if DCEVM updates Class Redefinition count.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@
                 <version>2.21.0</version>
                 <configuration>
                     <!--<jvm></jvm>-->
-                    <argLine>-javaagent:${basedir}/dcevm-tests-agent.jar -XXaltjvm=dcevm -Xlog:redefine+class*=info</argLine>
+                    <argLine>-javaagent:${basedir}/dcevm-tests-agent.jar -Xlog:redefine+class*=info</argLine>
+
                     <excludedGroups>com.github.dcevm.test.category.Full</excludedGroups>
                 </configuration>
             </plugin>

--- a/src/test/java/com/github/dcevm/test/TestUtil.java
+++ b/src/test/java/com/github/dcevm/test/TestUtil.java
@@ -27,6 +27,8 @@ package com.github.dcevm.test;
 import com.github.dcevm.HotSwapTool;
 import org.junit.Assert;
 
+import java.lang.reflect.Field;
+
 /**
  * Utility methods for unit testing.
  *
@@ -69,6 +71,19 @@ public class TestUtil {
         HotSwapTool.toVersion(clazz, version);
       }
     });
+  }
+
+  public static int getClassRedefinedCount(Class type) {
+    try {
+      Field field = Class.class.getDeclaredField("classRedefinedCount");
+      boolean accessibility = field.isAccessible();
+      field.setAccessible(true);
+      int classRedefinedCount = (Integer) field.get(type);
+      field.setAccessible(accessibility);
+      return  classRedefinedCount;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
 }

--- a/src/test/java/com/github/dcevm/test/fields/FieldOperationsUpdateClassRedefinedCountTest.java
+++ b/src/test/java/com/github/dcevm/test/fields/FieldOperationsUpdateClassRedefinedCountTest.java
@@ -1,0 +1,67 @@
+package com.github.dcevm.test.fields;
+import com.github.dcevm.HotSwapTool;
+import com.github.dcevm.test.TestUtil;
+import com.github.dcevm.test.category.Light;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import static com.github.dcevm.test.util.HotSwapTestHelper.__toVersion__;
+import static org.junit.Assert.assertEquals;
+
+public class FieldOperationsUpdateClassRedefinedCountTest {
+    // Version 0
+    public static class A {
+        public int x;
+        int getFieldInOldCode() {
+            __toVersion__(1);
+            // This field does no longer exist
+            return x;
+        }
+        int getVer() {
+            return 0;
+        }
+    }
+    // Version 1
+    public static class A___1 {
+        public int x;
+        public int y;
+        int getVer() {
+            return 1;
+        }
+    }
+    public static class A___2 {
+        int getVer() {
+            return 2;
+        }
+    }
+    @Before
+    public void setUp() throws Exception {
+        __toVersion__(0);
+    }
+    @Test
+    public void addingFieldUpdatesClassRedifinedCount() throws NoSuchFieldException, IllegalAccessException {
+        // setup
+        A a = new A();
+        __toVersion__(0);
+        int prevVersion = TestUtil.getClassRedefinedCount(A.class);
+        // examine
+        __toVersion__(1);
+        Object y = A.class.getDeclaredField("y").get(a);
+        // verify
+        assertEquals(0,y);
+        assertEquals(1, a.getVer());
+        assertEquals(prevVersion+1, TestUtil.getClassRedefinedCount(A.class));
+    }
+    @Test
+    public void deletingFieldUpdatesClassRedifinedCount() {
+        // setup
+        A a= new A();
+        __toVersion__(0);
+        int prevVersion = TestUtil.getClassRedefinedCount(A.class);
+        // examine
+        __toVersion__(2);
+        // verify
+        assertEquals(2, a.getVer());
+        assertEquals(prevVersion+1, TestUtil.getClassRedefinedCount(A.class));
+    }
+}

--- a/src/test/java/com/github/dcevm/test/methods/OperationsOnMethodsUpdateClassRedefinedCountTest.java
+++ b/src/test/java/com/github/dcevm/test/methods/OperationsOnMethodsUpdateClassRedefinedCountTest.java
@@ -1,0 +1,94 @@
+package com.github.dcevm.test.methods;
+import com.github.dcevm.test.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+import static com.github.dcevm.test.util.HotSwapTestHelper.__toVersion__;
+import static org.junit.Assert.assertEquals;
+public class OperationsOnMethodsUpdateClassRedefinedCountTest {
+    // Version 0
+    public static class A {
+        public int value(int newVersion) {
+            return newVersion;
+        }
+    }
+    // Version 1
+    public static class A___1 {
+        public int value(int newVersion) {
+            int x = 1;
+            try {
+                x = 2;
+            } catch (NumberFormatException e) {
+                x = 3;
+            } catch (Exception e) {
+                x = 4;
+            } finally {
+                x = x * 2;
+            }
+            __toVersion__(newVersion);
+            throw new IllegalArgumentException();
+        }
+    }
+    // Version 2
+    public static class A___2 {
+        public int value2() {
+            return 2;
+        }
+        public int value(int newVersion) {
+            int x = 1;
+            try {
+                x = 2;
+            } catch (NumberFormatException e) {
+                x = 3;
+            } catch (Exception e) {
+                x = 4;
+            } finally {
+                x = x * 2;
+            }
+            __toVersion__(newVersion);
+            throw new IllegalArgumentException();
+        }
+        public int value3() {
+            return 3;
+        }
+        public int value4() {
+            return 4;
+        }
+        public int value5() {
+            return 5;
+        }
+    }
+    @Before
+    public void setUp() throws Exception {
+        __toVersion__(0);
+    }
+    @Test
+    public void changingMethodUpdatesClassRedefinedCount() {
+        // setup
+        __toVersion__(0);
+        int prevVersion = TestUtil.getClassRedefinedCount(A.class);
+        // examine
+        __toVersion__(1);
+        // verify
+        assertEquals(prevVersion+1, TestUtil.getClassRedefinedCount(A.class));
+    }
+    @Test
+    public void addingMethodUpdatesClassRedefinedCount() {
+        // setup
+        __toVersion__(0);
+        int prevVersion = TestUtil.getClassRedefinedCount(A.class);
+        // examine
+        __toVersion__(2);
+        // verify
+        assertEquals(prevVersion+1, TestUtil.getClassRedefinedCount(A.class));
+    }
+    @Test
+    public void deletingMethodUpdatesClassRedefinedCount() {
+        // setup
+        __toVersion__(2);
+        int prevVersion = TestUtil.getClassRedefinedCount(A.class);
+        // examine
+        __toVersion__(0);
+        // verify
+        assertEquals(prevVersion+1, TestUtil.getClassRedefinedCount(A.class));
+    }
+}


### PR DESCRIPTION
Added 2 tests for checking if DCEVM updates Class Redefinition count.
Both are using method getClassRedefinedCount which was added to TestUtil.
In pom.xml removed -XXaltjvm=dcevm which doesn't work with DCEVM for JDK 11.